### PR TITLE
remove leading "=" in when building the URL

### DIFF
--- a/R/get_tests_team.R
+++ b/R/get_tests_team.R
@@ -117,7 +117,7 @@ get_tests_team <- function(teamId, from = NULL, to = NULL) {
   }
 
   # Create URL for request!!!!!!!
-  URL <- base::paste0(urlCloud,"?=teamId=", tId, fromDT, toDT)
+  URL <- base::paste0(urlCloud,"?teamId=", tId, fromDT, toDT)
 
   #-----#
 


### PR DESCRIPTION
the leading '=' is causing the teamId to be ignored.