### PR TITLE
v1.0.3 add sync and active parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hawkinR
 Title: R package to work with data from the Hawkin Dynamics API
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: 
     person("Lauren", "Green", , "lauren@hawkindynamics.com", role = c("aut", "cre"))
 Description: Provides simple functionality with Hawkin Dynamics API. These functions are for use with 'Hawkin Dynamics Beta API' version 1.8-beta. You must be an Hawkin Dynamics user with active integration account to utilize functions within the package. This API is designed to get data out of your Hawkin Dynamics database into your own database. It is not designed to be accessed from client applications directly. There is a limit on the amount of data that can be returned in a single request. As your database grows, it will be necessary to use the from and to parameters to limit the size of the responses. Responses that exceed the memory limit will fail.

--- a/R/get_tests.R
+++ b/R/get_tests.R
@@ -261,8 +261,12 @@ get_tests <- function(from = NULL, to = NULL, sync = FALSE, active = TRUE) {
     x <- if( base::isTRUE(active) ) {
       filt <- dplyr::filter(.data = x, active == TRUE)
 
+      filt <- dplyr::relocate(.data = filt, 'active', .before = 'timestamp')
+
       filt
-    } else {
+    } else if( base::isFALSE(active) ){
+      x <- dplyr::relocate(.data = x, 'active', .before = 'timestamp')
+
       x
     }
 

--- a/R/get_tests.R
+++ b/R/get_tests.R
@@ -4,7 +4,7 @@
 #' Get the tests for an account. You can specify a time frame from, or to, which the tests should come (or be synced).
 #'
 #' @usage
-#' get_tests(from, to, sync = FALSE)
+#' get_tests(from, to, sync = FALSE, active = TRUE)
 #'
 #' @param from Optionally supply a time (Unix timestamp) you want the tests from. If you do not
 #' supply this value you will receive every test. This parameter is best suited for bulk exports of
@@ -18,30 +18,37 @@
 #' suited to keep your database in sync with the Hawkin database. If you do not supply this value
 #' you will receive every test.
 #'
+#' @param active There was a change to the default API configuration to reflect the majority of
+#' users API configuration. Inactive tests or tests where `active:false` are returned in these
+#' configuration. Be default, `active` is set to TRUE. To return all tests, including disabled
+#' trials, set `active` to FALSE.
+#'
 #' @return
 #' Response will be a data frame containing the trials within the time range (if specified).
 #'
 #' **id**   *str*   Test trial unique ID
 #'
+#' **active**   *logi*   The trial is active and not disabled
+#'
 #' **timestamp**   *int*   UNIX timestamp of trial
 #'
 #' **segment**   *chr*   Description of the test type and trial number of the session (testType:trialNo)
 #'
-#' **testType.id**   *chr*   Id of the test type of the trial
+#' **testType_id**   *chr*   Id of the test type of the trial
 #'
-#' **testType.name**   *chr*   Name of the test type of the trial
+#' **testType_name**   *chr*   Name of the test type of the trial
 #'
-#' **testType.canonicalId**   *chr*   Canonical Id of the test type of the trial
+#' **testType_canonicalId**   *chr*   Canonical Id of the test type of the trial
 #'
-#' **athlete.id**   *chr*   Unique Id of the athlete
+#' **athlete_id**   *chr*   Unique Id of the athlete
 #'
-#' **athlete.name**   *chr*   Athlete given name
+#' **athlete_name**   *chr*   Athlete given name
 #'
-#' **athlete.active**   *logi*   The athlete is active
+#' **athlete_active**   *logi*   The athlete is active
 #'
-#' **athlete.teams**   *list*   List containing Ids of each team the athlete is on
+#' **athlete_teams**   *list*   List containing Ids of each team the athlete is on
 #'
-#' **athlete.groups**   *list*   List containing Ids of each group the athlete is in
+#' **athlete_groups**   *list*   List containing Ids of each group the athlete is in
 #'
 #' All metrics from each test type are included as the remaining variables.
 #' If a trial does not have data for a variable it is returned NA.
@@ -72,7 +79,7 @@
 #' @export
 
 ## Get All Tests or Sync Tests -----
-get_tests <- function(from = NULL, to = NULL, sync = FALSE) {
+get_tests <- function(from = NULL, to = NULL, sync = FALSE, active = TRUE) {
 
   # Retrieve Access Token and Expiration from Environment Variables
   aToken <- base::Sys.getenv("accessToken")
@@ -250,6 +257,16 @@ get_tests <- function(from = NULL, to = NULL, sync = FALSE) {
     # Clean colnames with janitor
     x <- janitor::clean_names(x)
 
+    # filter inactive tests
+    x <- if( base::isTRUE(active) ) {
+      filt <- dplyr::filter(.data = x, active == TRUE)
+
+      filt
+    } else {
+      x
+    }
+
+    # return final DF
     x
   }
 

--- a/R/get_tests_ath.R
+++ b/R/get_tests_ath.R
@@ -261,8 +261,12 @@ get_tests_ath <- function(athleteId, from = NULL, to = NULL, sync = FALSE, activ
       x <- if( base::isTRUE(active) ) {
         filt <- dplyr::filter(.data = x, active == TRUE)
 
+        filt <- dplyr::relocate(.data = filt, 'active', .before = 'timestamp')
+
         filt
       } else if( base::isFALSE(active) ){
+        x <- dplyr::relocate(.data = x, 'active', .before = 'timestamp')
+
         x
       }
 

--- a/R/get_tests_ath.R
+++ b/R/get_tests_ath.R
@@ -4,7 +4,7 @@
 #' Get only tests of the specified athlete for an account.
 #'
 #' @usage
-#' get_tests_ath(athleteId, from, to, sync)
+#' get_tests_ath(athleteId, from, to, sync = FALSE, active = TRUE)
 #'
 #' @param athleteId Supply an athlete’s id to receive tests for a specific athlete
 #'
@@ -20,10 +20,18 @@
 #' suited to keep your database in sync with the Hawkin database. If you do not supply this value
 #' you will receive every test.
 #'
+#' @param active There was a change to the default API configuration to reflect the majority of
+#' users API configuration. Inactive tests or tests where `active:false` are returned in these
+#' configuration. Be default, `active` is set to TRUE. To return all tests, including disabled
+#' trials, set `active` to FALSE.
+#'
 #' @return
-#' Response will be a data frame containing the trials from the specified team and within the time range (if specified).
+#' Response will be a data frame containing the trials from the specified team and within the time
+#' range (if specified).
 #'
 #' **id**   *str*   Test trial unique ID
+#'
+#' **active**   *logi*   The trial is active and not disabled
 #'
 #' **timestamp**   *int*   UNIX timestamp of trial
 #'
@@ -73,7 +81,7 @@
 #' @export
 
 ## Get Tests Data by Athlete Id -----
-get_tests_ath <- function(athleteId, from = NULL, to = NULL, sync = FALSE) {
+get_tests_ath <- function(athleteId, from = NULL, to = NULL, sync = FALSE, active = TRUE) {
 
   # Retrieve Access Token and Expiration from Environment Variables
   aToken <- base::Sys.getenv("accessToken")
@@ -249,6 +257,16 @@ get_tests_ath <- function(athleteId, from = NULL, to = NULL, sync = FALSE) {
       # Clean colnames with janitor
       x <- janitor::clean_names(x)
 
+      # filter inactive tests
+      x <- if( base::isTRUE(active) ) {
+        filt <- dplyr::filter(.data = x, active == TRUE)
+
+        filt
+      } else if( base::isFALSE(active) ){
+        x
+      }
+
+      # return final DF
       x
     } else {
       base::stop("No trials returned. Check athleteId or from/to entries")

--- a/R/get_tests_group.R
+++ b/R/get_tests_group.R
@@ -4,7 +4,7 @@
 #' Get only tests of the specified group for an account.
 #'
 #' @usage
-#' get_tests_group(groupId, from, to, sync)
+#' get_tests_group(groupId, from, to, sync = FALSE, active = TRUE)
 #'
 #' @param groupId Supply a group’s or a string of a comma separated list of group id’s to receive tests from
 #' specific groups. Recommended to use method `paste0()`. A maximum of 10 groups can be fetched at once.
@@ -21,11 +21,18 @@
 #' suited to keep your database in sync with the Hawkin database. If you do not supply this value
 #' you will receive every test.
 #'
+#' @param active There was a change to the default API configuration to reflect the majority of
+#' users API configuration. Inactive tests or tests where `active:false` are returned in these
+#' configuration. Be default, `active` is set to TRUE. To return all tests, including disabled
+#' trials, set `active` to FALSE.
+#'
 #' @return
 #' Response will be a data frame containing the trials from the specified team and within the time
 #' range (if specified).
 #'
 #' **id**   *str*   Test trial unique ID
+#'
+#' **active**   *logi*   The trial is active and not disabled
 #'
 #' **timestamp**   *int*   UNIX timestamp of trial
 #'
@@ -75,7 +82,7 @@
 #' @export
 
 ## Get Tests Data by Group Id -----
-get_tests_group <- function(groupId, from = NULL, to = NULL, sync = FALSE) {
+get_tests_group <- function(groupId, from = NULL, to = NULL, sync = FALSE, active = TRUE) {
 
   # Retrieve Access Token and Expiration from Environment Variables
   aToken <- base::Sys.getenv("accessToken")
@@ -279,6 +286,16 @@ get_tests_group <- function(groupId, from = NULL, to = NULL, sync = FALSE) {
       # Clean colnames with janitor
       x <- janitor::clean_names(x)
 
+      # filter inactive tests
+      x <- if( base::isTRUE(active) ) {
+        filt <- dplyr::filter(.data = x, active == TRUE)
+
+        filt
+      } else if( base::isFALSE(active) ){
+        x
+      }
+
+      # return final DF
       x
 
     } else {

--- a/R/get_tests_group.R
+++ b/R/get_tests_group.R
@@ -290,8 +290,12 @@ get_tests_group <- function(groupId, from = NULL, to = NULL, sync = FALSE, activ
       x <- if( base::isTRUE(active) ) {
         filt <- dplyr::filter(.data = x, active == TRUE)
 
+        filt <- dplyr::relocate(.data = filt, 'active', .before = 'timestamp')
+
         filt
       } else if( base::isFALSE(active) ){
+        x <- dplyr::relocate(.data = x, 'active', .before = 'timestamp')
+
         x
       }
 

--- a/R/get_tests_team.R
+++ b/R/get_tests_team.R
@@ -4,7 +4,7 @@
 #' Get only tests of the specified team for an account.
 #'
 #' @usage
-#' get_tests_team(teamId, from, to, sync)
+#' get_tests_team(teamId, from, to, sync = FALSE, active = TRUE)
 #'
 #' @param teamId Supply a team’s or a string of a comma separated list of group id’s to receive tests from
 #' specific groups. Recommended to use method `paste0()`. A maximum of 10 groups can be fetched at once.
@@ -21,10 +21,18 @@
 #' suited to keep your database in sync with the Hawkin database. If you do not supply this value
 #' you will receive every test.
 #'
+#' @param active There was a change to the default API configuration to reflect the majority of
+#' users API configuration. Inactive tests or tests where `active:false` are returned in these
+#' configuration. Be default, `active` is set to TRUE. To return all tests, including disabled
+#' trials, set `active` to FALSE.
+#'
 #' @return
-#' Response will be a data frame containing the trials from the specified team and within the time range (if specified).
+#' Response will be a data frame containing the trials from the specified team and within the time
+#' range (if specified).
 #'
 #' **id**   *str*   Test trial unique ID
+#'
+#' **active**   *logi*   The trial is active and not disabled
 #'
 #' **timestamp**   *int*   UNIX timestamp of trial
 #'
@@ -74,7 +82,7 @@
 #' @export
 
 ## Get Tests Data by Team Id -----
-get_tests_team <- function(teamId, from = NULL, to = NULL, sync = FALSE) {
+get_tests_team <- function(teamId, from = NULL, to = NULL, sync = FALSE, active = TRUE) {
 
   # Retrieve Access Token and Expiration from Environment Variables
   aToken <- base::Sys.getenv("accessToken")
@@ -278,6 +286,16 @@ get_tests_team <- function(teamId, from = NULL, to = NULL, sync = FALSE) {
       # Clean colnames with janitor
       x <- janitor::clean_names(x)
 
+      # filter inactive tests
+      x <- if( base::isTRUE(active) ) {
+        filt <- dplyr::filter(.data = x, active == TRUE)
+
+        filt
+      } else if( base::isFALSE(active) ){
+        x
+      }
+
+      # return final DF
       x
 
     } else {
@@ -293,3 +311,4 @@ get_tests_team <- function(teamId, from = NULL, to = NULL, sync = FALSE) {
   return(Resp)
 
 }
+

--- a/R/get_tests_team.R
+++ b/R/get_tests_team.R
@@ -290,8 +290,12 @@ get_tests_team <- function(teamId, from = NULL, to = NULL, sync = FALSE, active 
       x <- if( base::isTRUE(active) ) {
         filt <- dplyr::filter(.data = x, active == TRUE)
 
+        filt <- dplyr::relocate(.data = filt, 'active', .before = 'timestamp')
+
         filt
       } else if( base::isFALSE(active) ){
+        x <- dplyr::relocate(.data = x, 'active', .before = 'timestamp')
+
         x
       }
 

--- a/R/get_tests_type.R
+++ b/R/get_tests_type.R
@@ -280,8 +280,12 @@ get_tests_type <- function(typeId, from = NULL, to = NULL, sync = FALSE, active=
     x <- if( base::isTRUE(active) ) {
       filt <- dplyr::filter(.data = x, active == TRUE)
 
+      filt <- dplyr::relocate(.data = filt, 'active', .before = 'timestamp')
+
       filt
-    } else {
+    } else if( base::isFALSE(active) ){
+      x <- dplyr::relocate(.data = x, 'active', .before = 'timestamp')
+
       x
     }
 

--- a/R/get_tests_type.R
+++ b/R/get_tests_type.R
@@ -4,7 +4,7 @@
 #' Get only tests of the specified type for an account.
 #'
 #' @usage
-#' get_tests_type(typeId, from, to, sync)
+#' get_tests_type(typeId, from, to, sync = FALSE, active = TRUE)
 #'
 #' @param typeId Supply a test type id to only retrieve tests of that type.
 #'
@@ -20,10 +20,17 @@
 #' suited to keep your database in sync with the Hawkin database. If you do not supply this value
 #' you will receive every test.
 #'
+#' @param active There was a change to the default API configuration to reflect the majority of
+#' users API configuration. Inactive tests or tests where `active:false` are returned in these
+#' configuration. Be default, `active` is set to TRUE. To return all tests, including disabled
+#' trials, set `active` to FALSE.
+#'
 #' @return
 #' Response will be a data frame containing the trials of the specified type and within the time range (if specified).
 #'
 #' **id**   *str*   Test trial unique ID
+#'
+#' **active**   *logi*   The trial is active and not disabled
 #'
 #' **timestamp**   *int*   UNIX timestamp of trial
 #'
@@ -73,7 +80,7 @@
 
 
 ## Get Tests Data by Test Type -----
-get_tests_type <- function(typeId, from = NULL, to = NULL, sync = FALSE) {
+get_tests_type <- function(typeId, from = NULL, to = NULL, sync = FALSE, active= TRUE) {
 
   # Retrieve Access Token and Expiration from Environment Variables
   aToken <- base::Sys.getenv("accessToken")
@@ -269,6 +276,16 @@ get_tests_type <- function(typeId, from = NULL, to = NULL, sync = FALSE) {
     # Clean colnames with janitor
     x <- janitor::clean_names(x)
 
+    # filter inactive tests
+    x <- if( base::isTRUE(active) ) {
+      filt <- dplyr::filter(.data = x, active == TRUE)
+
+      filt
+    } else {
+      x
+    }
+
+    # return final DF
     x
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml) [![Last-changedate](https://img.shields.io/badge/last%20change-`r gsub('-', '--', Sys.Date())`-yellowgreen.svg)](/commits/master) [![license](https://img.shields.io/badge/license-MIT%20+%20file%20LICENSE-lightgrey.svg)](https://choosealicense.com/) 
 [![minimal R version](https://img.shields.io/badge/R%3E%3D-`r "3.5.0"`-6666ff.svg)](https://cran.r-project.org/) 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable) 
-[![packageversion](https://img.shields.io/badge/Package%20version-`r "1.0.2"`-orange.svg?style=flat-square)](commits/master) 
+[![packageversion](https://img.shields.io/badge/Package%20version-`r "1.0.3"`-orange.svg?style=flat-square)](commits/master) 
 [![thanks-md](https://img.shields.io/badge/THANKS-md-ff69b4.svg)](THANKS.md)
 
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml)
-[![Last-changedate](https://img.shields.io/badge/last%20change-2023--11--07-yellowgreen.svg)](/commits/master)
+[![Last-changedate](https://img.shields.io/badge/last%20change-2024--01--22-yellowgreen.svg)](/commits/master)
 [![license](https://img.shields.io/badge/license-MIT%20+%20file%20LICENSE-lightgrey.svg)](https://choosealicense.com/)
 [![minimal R
 version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-project.org/)
@@ -16,7 +16,7 @@ version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
-[![packageversion](https://img.shields.io/badge/Package%20version-1.0.2-orange.svg?style=flat-square)](commits/master)
+[![packageversion](https://img.shields.io/badge/Package%20version-1.0.3-orange.svg?style=flat-square)](commits/master)
 [![thanks-md](https://img.shields.io/badge/THANKS-md-ff69b4.svg)](THANKS.md)
 
 <!-- badges: end -->

--- a/man/get_tests.Rd
+++ b/man/get_tests.Rd
@@ -4,7 +4,7 @@
 \alias{get_tests}
 \title{Get All Tests or Sync Tests}
 \usage{
-get_tests(from, to, sync = FALSE)
+get_tests(from, to, sync = FALSE, active = TRUE)
 }
 \arguments{
 \item{from}{Optionally supply a time (Unix timestamp) you want the tests from. If you do not
@@ -18,31 +18,38 @@ supplied \code{from} parameter. This parameter is best suited for bulk exports o
 \item{sync}{The result set will include updated and newly created tests. This parameter is best
 suited to keep your database in sync with the Hawkin database. If you do not supply this value
 you will receive every test.}
+
+\item{active}{There was a change to the default API configuration to reflect the majority of
+users API configuration. Inactive tests or tests where \code{active:false} are returned in these
+configuration. Be default, \code{active} is set to TRUE. To return all tests, including disabled
+trials, set \code{active} to FALSE.}
 }
 \value{
 Response will be a data frame containing the trials within the time range (if specified).
 
 \strong{id}   \emph{str}   Test trial unique ID
 
+\strong{active}   \emph{logi}   The trial is active and not disabled
+
 \strong{timestamp}   \emph{int}   UNIX timestamp of trial
 
 \strong{segment}   \emph{chr}   Description of the test type and trial number of the session (testType:trialNo)
 
-\strong{testType.id}   \emph{chr}   Id of the test type of the trial
+\strong{testType_id}   \emph{chr}   Id of the test type of the trial
 
-\strong{testType.name}   \emph{chr}   Name of the test type of the trial
+\strong{testType_name}   \emph{chr}   Name of the test type of the trial
 
-\strong{testType.canonicalId}   \emph{chr}   Canonical Id of the test type of the trial
+\strong{testType_canonicalId}   \emph{chr}   Canonical Id of the test type of the trial
 
-\strong{athlete.id}   \emph{chr}   Unique Id of the athlete
+\strong{athlete_id}   \emph{chr}   Unique Id of the athlete
 
-\strong{athlete.name}   \emph{chr}   Athlete given name
+\strong{athlete_name}   \emph{chr}   Athlete given name
 
-\strong{athlete.active}   \emph{logi}   The athlete is active
+\strong{athlete_active}   \emph{logi}   The athlete is active
 
-\strong{athlete.teams}   \emph{list}   List containing Ids of each team the athlete is on
+\strong{athlete_teams}   \emph{list}   List containing Ids of each team the athlete is on
 
-\strong{athlete.groups}   \emph{list}   List containing Ids of each group the athlete is in
+\strong{athlete_groups}   \emph{list}   List containing Ids of each group the athlete is in
 
 All metrics from each test type are included as the remaining variables.
 If a trial does not have data for a variable it is returned NA.

--- a/man/get_tests_ath.Rd
+++ b/man/get_tests_ath.Rd
@@ -4,7 +4,7 @@
 \alias{get_tests_ath}
 \title{Get Test Trials By Athlete}
 \usage{
-get_tests_ath(athleteId, from, to, sync)
+get_tests_ath(athleteId, from, to, sync = FALSE, active = TRUE)
 }
 \arguments{
 \item{athleteId}{Supply an athlete’s id to receive tests for a specific athlete}
@@ -20,11 +20,19 @@ supplied \code{from} parameter. This parameter is best suited for bulk exports o
 \item{sync}{The result set will include updated and newly created tests. This parameter is best
 suited to keep your database in sync with the Hawkin database. If you do not supply this value
 you will receive every test.}
+
+\item{active}{There was a change to the default API configuration to reflect the majority of
+users API configuration. Inactive tests or tests where \code{active:false} are returned in these
+configuration. Be default, \code{active} is set to TRUE. To return all tests, including disabled
+trials, set \code{active} to FALSE.}
 }
 \value{
-Response will be a data frame containing the trials from the specified team and within the time range (if specified).
+Response will be a data frame containing the trials from the specified team and within the time
+range (if specified).
 
 \strong{id}   \emph{str}   Test trial unique ID
+
+\strong{active}   \emph{logi}   The trial is active and not disabled
 
 \strong{timestamp}   \emph{int}   UNIX timestamp of trial
 

--- a/man/get_tests_group.Rd
+++ b/man/get_tests_group.Rd
@@ -4,7 +4,7 @@
 \alias{get_tests_group}
 \title{Get Test Trials By Groups}
 \usage{
-get_tests_group(groupId, from, to, sync)
+get_tests_group(groupId, from, to, sync = FALSE, active = TRUE)
 }
 \arguments{
 \item{groupId}{Supply a group’s or a string of a comma separated list of group id’s to receive tests from
@@ -21,12 +21,19 @@ supplied \code{from} parameter. This parameter is best suited for bulk exports o
 \item{sync}{The result set will include updated and newly created tests. This parameter is best
 suited to keep your database in sync with the Hawkin database. If you do not supply this value
 you will receive every test.}
+
+\item{active}{There was a change to the default API configuration to reflect the majority of
+users API configuration. Inactive tests or tests where \code{active:false} are returned in these
+configuration. Be default, \code{active} is set to TRUE. To return all tests, including disabled
+trials, set \code{active} to FALSE.}
 }
 \value{
 Response will be a data frame containing the trials from the specified team and within the time
 range (if specified).
 
 \strong{id}   \emph{str}   Test trial unique ID
+
+\strong{active}   \emph{logi}   The trial is active and not disabled
 
 \strong{timestamp}   \emph{int}   UNIX timestamp of trial
 

--- a/man/get_tests_team.Rd
+++ b/man/get_tests_team.Rd
@@ -4,7 +4,7 @@
 \alias{get_tests_team}
 \title{Get Test Trials By Teams}
 \usage{
-get_tests_team(teamId, from, to, sync)
+get_tests_team(teamId, from, to, sync = FALSE, active = TRUE)
 }
 \arguments{
 \item{teamId}{Supply a team’s or a string of a comma separated list of group id’s to receive tests from
@@ -21,11 +21,19 @@ supplied \code{from} parameter. This parameter is best suited for bulk exports o
 \item{sync}{The result set will include updated and newly created tests. This parameter is best
 suited to keep your database in sync with the Hawkin database. If you do not supply this value
 you will receive every test.}
+
+\item{active}{There was a change to the default API configuration to reflect the majority of
+users API configuration. Inactive tests or tests where \code{active:false} are returned in these
+configuration. Be default, \code{active} is set to TRUE. To return all tests, including disabled
+trials, set \code{active} to FALSE.}
 }
 \value{
-Response will be a data frame containing the trials from the specified team and within the time range (if specified).
+Response will be a data frame containing the trials from the specified team and within the time
+range (if specified).
 
 \strong{id}   \emph{str}   Test trial unique ID
+
+\strong{active}   \emph{logi}   The trial is active and not disabled
 
 \strong{timestamp}   \emph{int}   UNIX timestamp of trial
 

--- a/man/get_tests_type.Rd
+++ b/man/get_tests_type.Rd
@@ -4,7 +4,7 @@
 \alias{get_tests_type}
 \title{Get Test Trials By Test Type}
 \usage{
-get_tests_type(typeId, from, to, sync)
+get_tests_type(typeId, from, to, sync = FALSE, active = TRUE)
 }
 \arguments{
 \item{typeId}{Supply a test type id to only retrieve tests of that type.}
@@ -20,11 +20,18 @@ supplied \code{from} parameter. This parameter is best suited for bulk exports o
 \item{sync}{The result set will include updated and newly created tests. This parameter is best
 suited to keep your database in sync with the Hawkin database. If you do not supply this value
 you will receive every test.}
+
+\item{active}{There was a change to the default API configuration to reflect the majority of
+users API configuration. Inactive tests or tests where \code{active:false} are returned in these
+configuration. Be default, \code{active} is set to TRUE. To return all tests, including disabled
+trials, set \code{active} to FALSE.}
 }
 \value{
 Response will be a data frame containing the trials of the specified type and within the time range (if specified).
 
 \strong{id}   \emph{str}   Test trial unique ID
+
+\strong{active}   \emph{logi}   The trial is active and not disabled
 
 \strong{timestamp}   \emph{int}   UNIX timestamp of trial
 


### PR DESCRIPTION
- updated get_tests calls to include sync and active parameters to filter inactive tests.
- relocate active column to behind id
- updated version number