### PR TITLE
hawkinR v1.2.0 - athlete profile fields and external property fixes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^hawkinRlog.log
+^.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ https://github.com/HawkinDynamics/hawkinR/tree/dev
 docs
 hawkinR.Rproj
 .Rhistory
+hawkinRlog.log
+.claude/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hawkinR
 Title: hawkinR - Hawkin Dynamics API
-Version: 1.1.5
+Version: 1.2.0
 Authors@R: 
     person("Lauren", "Green", , "lauren@hawkindynamics.com", role = c("aut", "cre"))
 Description: Provides simple functionality with Hawkin Dynamics API. These functions are for use with 'Hawkin Dynamics Beta API' version 1.8-beta. You must be an Hawkin Dynamics user with active integration account to utilize functions within the package. This API is designed to get data out of your Hawkin Dynamics database into your own database. It is not designed to be accessed from client applications directly. There is a limit on the amount of data that can be returned in a single request. As your database grows, it will be necessary to use the from and to parameters to limit the size of the responses. Responses that exceed the memory limit will fail.
@@ -10,7 +10,7 @@ Depends: R (>= 3.5.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     dplyr (>= 0.7.4),
     jsonlite (>= 1.8.7),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## hawkinR v1.2.0
+
+* Addition of athlete profile fields (`image`, `position`, `dob`, `sport`, `height`, `lastTestedOn`) to `get_athletes()` returns
+
+* Addition of athlete profile fields (`athlete_image`, `athlete_position`, `athlete_dob`, `athlete_sport`, `athlete_height`) to `get_tests()` returns
+
+* Bug fix: rewrote external property handling in `get_athletes()` and `AthletePrep()` to correctly unnest external value pairs into separate columns, including varying keys across athletes
+
+* Bug fix: `get_access()` now uses the supplied `org_name` for the `Dev` region and defaults to `v1` instead of `dev`
+
 ## hawkinR v1.1.5
 
 * fix to R/utils/ParamValidation duplicated date format check.

--- a/R/get_access.R
+++ b/R/get_access.R
@@ -85,7 +85,7 @@ get_access <- function(refreshToken, region = "Americas", org_name = NULL) {
   orgName <- if(!is.null(org_name)) {
     org_name
   } else {
-    "dev"
+    "v1"
   }
 
   urlCloud <- base::switch(
@@ -93,7 +93,7 @@ get_access <- function(refreshToken, region = "Americas", org_name = NULL) {
     "Americas" = paste0("https://cloud.hawkindynamics.com/api/", orgName),
     "Europe" = paste0("https://eu.cloud.hawkindynamics.com/api/", orgName),
     "Asia/Pacific" = paste0("https://apac.cloud.hawkindynamics.com/api/", orgName),
-    "Dev" = "https://cloud.dev.hawkindynamics.com/api/dev"
+    "Dev" = paste0("https://cloud.dev.hawkindynamics.com/api/", orgName)
   )
 
   # Log Debug

--- a/R/get_athletes.R
+++ b/R/get_athletes.R
@@ -21,6 +21,12 @@
 #' | **active**      | *bool*   | athlete is active (TRUE) |
 #' | **teams**       | *chr*    | team ids separated by "," |
 #' | **groups**      | *chr*    | group ids separated by "," |
+#' | **image**       | *chr*    | URL to athlete's profile image |
+#' | **position**    | *chr*    | athlete's position |
+#' | **dob**         | *chr*    | athlete's date of birth |
+#' | **sport**       | *chr*    | athlete's sport |
+#' | **height**      | *chr*    | athlete's height |
+#' | **lastTestedOn** | *chr*    | date of athlete's last test |
 #' | **external**    | *chr*    | external properties will have a column of their name with the appropriate values for the athlete of `NA` if it does not apply |
 #'
 #' @examples
@@ -147,20 +153,41 @@ get_athletes <- function(includeInactive = FALSE) {
     # Create data frame from returns data
     df <- base::as.data.frame(x[[1]])
 
-    # Handle External Properties
-    if (base::ncol(df) > 5) {
-      # Select base athlete attributes
-      a <- df[, 1:5]
-      # Select any external value pairs
-      b <- df[, 6:base::ncol(df)]
+    # Explicit response columns to pull out of the response.
+    core_cols    <- c("id", "name", "active", "teams", "groups", "image")
+    profile_cols <- c( "position", "dob", "sport", "height", "lastTestedOn")
 
-      # Return new data frame with externals expanded
-      return(base::cbind(a, b))
-    } else {
-      # Return data frame
-      return(df)
+    # What's present in this response
+    present_core    <- intersect(core_cols,    names(df))
+    present_profile <- intersect(profile_cols, names(df))
+
+    # Core + profile block
+    known_df <- df[, c(present_core, present_profile), drop = FALSE]
+
+    # External block — unnest the list-column into one column per key
+    if ("external" %in% names(df)) {
+      # Discover every key that appears across all rows
+      ext_keys <- base::unique(base::unlist(base::lapply(df$external, base::names)))
+
+      if (base::length(ext_keys) > 0L) {
+        ext_df <- base::as.data.frame(
+          base::lapply(ext_keys, function(k) {
+            base::vapply(df$external, function(row_ext) {
+              if (base::is.null(row_ext) || base::is.null(row_ext[[k]])) {
+                NA_character_
+              } else {
+                base::as.character(row_ext[[k]])
+              }
+            }, character(1))
+          }),
+          stringsAsFactors = FALSE
+        )
+        base::colnames(ext_df) <- ext_keys
+
+        known_df <- base::cbind(known_df, ext_df)
+      }
     }
+
+    return(known_df)
   }
 }
-
-

--- a/R/get_tests.R
+++ b/R/get_tests.R
@@ -84,6 +84,11 @@
 #' | **athlete_active** | *logi* | The athlete is active |
 #' | **athlete_teams** | *list* | List containing Ids of each team the athlete is on |
 #' | **athlete_groups** | *list* | List containing Ids of each group the athlete is in |
+#' | **athlete_image** | *chr* | URL to athlete's profile image |
+#' | **athlete_position** | *chr* | Athlete's position |
+#' | **athlete_dob** | *chr* | Athlete's date of birth |
+#' | **athlete_sport** | *chr* | Athlete's sport |
+#' | **athlete_height** | *chr* | Athlete's height |
 #'
 #' All metrics from each test type are included as the remaining variables
 #' unless `typeId` is provided, then only the metrics of that test type will be returned.

--- a/R/utils.R
+++ b/R/utils.R
@@ -229,32 +229,81 @@ TestTypePrep <- function(arg_df) {
 
 #' Construct Athlete df
 #'
-#' Take athlete section from data frame and prep for final data frame
+#' Take athlete section from data frame and prep for final data frame.
+#' Uses the same v1.14 schema as get_athletes() — id/name/active/teams/
+#' groups/image are explicit core columns; position/dob/sport/height/
+#' lastTestedOn are optional and only appear when at least one athlete
+#' has the field populated; external is a nested object unnested into
+#' separate columns. Everything is prefixed with "athlete_" so test
+#' rows can namespace athlete data alongside metrics.
 #'
 #' @param arg_df Data frame to be evaluated.
-#' @return data frame of test type information
+#' @return data frame of athlete information, all columns prefixed "athlete_"
 #' @keywords internal
 AthletePrep <- function(arg_df) {
 
-  # 1. Isolate Expected Athlete Columns from Athlete Section
-  athleteData <- arg_df[1:5]
-  base::colnames(athleteData) <- base::paste0("athlete_", base::colnames(athleteData))
-
-  # 2. Check for External
-  externalData <- arg_df[[6]]
-
-  # 3. Reformat and Add External Data if Present
-  if (ncol(externalData) > 0) {
-    # A. Reformat External Data names
-    externalData <- janitor::clean_names(externalData)
-    base::colnames(externalData) <- base::paste0("athlete_", base::colnames(externalData))
-
-    # B. Combine Basic Athlete and External data
-    return(base::cbind(athleteData, externalData))
-  } else {
-    # A. Return Basic Athlete Data
-    return(athleteData)
+  # Defensive guards
+  if (base::is.null(arg_df) || base::length(arg_df) == 0L) {
+    return(base::data.frame())
   }
+  if (!base::is.data.frame(arg_df)) {
+    arg_df <- base::as.data.frame(arg_df, stringsAsFactors = FALSE)
+  }
+
+  # Authoritative v1.14 athlete schema
+  core_cols    <- c("id", "name", "active", "teams", "groups", "image")
+  profile_cols <- c("position", "dob", "sport", "height", "lastTestedOn")
+
+  # What this response actually contained
+  present_core    <- base::intersect(core_cols,    base::names(arg_df))
+  present_profile <- base::intersect(profile_cols, base::names(arg_df))
+
+  # Core + profile block, prefixed
+  known_df <- arg_df[, c(present_core, present_profile), drop = FALSE]
+  base::colnames(known_df) <- base::paste0("athlete_", base::colnames(known_df))
+
+  # Handle nested external if present
+  if (!"external" %in% base::names(arg_df)) {
+    return(known_df)
+  }
+
+  externalData <- arg_df[["external"]]
+  ext_df <- NULL
+
+  # external can be a sub-data-frame (uniform keys across rows) or a
+  # list-column (varying keys). Normalize to a data frame.
+  if (base::is.data.frame(externalData) && base::ncol(externalData) > 0L) {
+    ext_df <- externalData
+
+  } else if (base::is.list(externalData)) {
+    ext_keys <- base::unique(base::unlist(base::lapply(externalData, base::names)))
+    ext_keys <- ext_keys[!base::is.na(ext_keys)]
+
+    if (base::length(ext_keys) > 0L) {
+      ext_df <- base::as.data.frame(
+        base::lapply(ext_keys, function(k) {
+          base::vapply(externalData, function(row_ext) {
+            if (base::is.null(row_ext) || base::is.null(row_ext[[k]])) {
+              NA_character_
+            } else {
+              base::as.character(row_ext[[k]])
+            }
+          }, character(1))
+        }),
+        stringsAsFactors = FALSE
+      )
+      base::colnames(ext_df) <- ext_keys
+    }
+  }
+
+  # Combine if we have external data, prefixed for namespacing
+  if (!base::is.null(ext_df) && base::ncol(ext_df) > 0L) {
+    ext_df <- janitor::clean_names(ext_df)
+    base::colnames(ext_df) <- base::paste0("athlete_", base::colnames(ext_df))
+    return(base::cbind(known_df, ext_df))
+  }
+
+  return(known_df)
 }
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,12 +23,12 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/HawkinDynamics/hawkinR/actions/workflows/R-CMD-check.yaml) [![Last-changedate](https://img.shields.io/badge/last%20change-%60r%20gsub('-',%20'--',%20Sys.Date())%60-yellowgreen.svg)](/commits/master) [![license](https://img.shields.io/badge/license-MIT%20+%20file%20LICENSE-lightgrey.svg)](https://choosealicense.com/) 
 [![minimal R version](https://img.shields.io/badge/R%3E%3D-`r "3.5.0"`-6666ff.svg)](https://cran.r-project.org/) 
 [![Project Status: Active -- The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable) 
-[![packageversion](https://img.shields.io/badge/Package%20version-`r "1.1.5"`-orange.svg?style=flat-square)](commits/master) 
+[![packageversion](https://img.shields.io/badge/Package%20version-`r "1.2.0"`-orange.svg?style=flat-square)](commits/master) 
 [![thanks-md](https://img.shields.io/badge/THANKS-md-ff69b4.svg)](THANKS.md)
 
 <!-- badges: end -->
 
-hawkinR provides simple functionality with Hawkin Dynamics API. These functions are for use with 'Hawkin Dynamics Beta API' version 1.10-beta. You must be an Hawkin Dynamics user with active integration account to utilize functions within the package.
+hawkinR provides simple functionality with Hawkin Dynamics API. These functions are for use with 'Hawkin Dynamics Beta API' version 1.14-beta. You must be an Hawkin Dynamics user with active integration account to utilize functions within the package.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
-[![packageversion](https://img.shields.io/badge/Package%20version-1.1.5-orange.svg?style=flat-square)](commits/master)
+[![packageversion](https://img.shields.io/badge/Package%20version-1.2.0-orange.svg?style=flat-square)](commits/master)
 [![thanks-md](https://img.shields.io/badge/THANKS-md-ff69b4.svg)](THANKS.md)
 
 <!-- badges: end -->
 
 hawkinR provides simple functionality with Hawkin Dynamics API. These
-functions are for use with ‘Hawkin Dynamics Beta API’ version 1.10-beta.
+functions are for use with ‘Hawkin Dynamics Beta API’ version 1.14-beta.
 You must be an Hawkin Dynamics user with active integration account to
 utilize functions within the package.
 

--- a/man/AthletePrep.Rd
+++ b/man/AthletePrep.Rd
@@ -10,9 +10,15 @@ AthletePrep(arg_df)
 \item{arg_df}{Data frame to be evaluated.}
 }
 \value{
-data frame of test type information
+data frame of athlete information, all columns prefixed "athlete_"
 }
 \description{
-Take athlete section from data frame and prep for final data frame
+Take athlete section from data frame and prep for final data frame.
+Uses the same v1.14 schema as get_athletes() — id/name/active/teams/
+groups/image are explicit core columns; position/dob/sport/height/
+lastTestedOn are optional and only appear when at least one athlete
+has the field populated; external is a nested object unnested into
+separate columns. Everything is prefixed with "athlete_" so test
+rows can namespace athlete data alongside metrics.
 }
 \keyword{internal}

--- a/man/get_athletes.Rd
+++ b/man/get_athletes.Rd
@@ -19,6 +19,12 @@ Each athlete includes the following variables:\tabular{lll}{
    \strong{active} \tab \emph{bool} \tab athlete is active (TRUE) \cr
    \strong{teams} \tab \emph{chr} \tab team ids separated by "," \cr
    \strong{groups} \tab \emph{chr} \tab group ids separated by "," \cr
+   \strong{image} \tab \emph{chr} \tab URL to athlete's profile image \cr
+   \strong{position} \tab \emph{chr} \tab athlete's position \cr
+   \strong{dob} \tab \emph{chr} \tab athlete's date of birth \cr
+   \strong{sport} \tab \emph{chr} \tab athlete's sport \cr
+   \strong{height} \tab \emph{chr} \tab athlete's height \cr
+   \strong{lastTestedOn} \tab \emph{chr} \tab date of athlete's last test \cr
    \strong{external} \tab \emph{chr} \tab external properties will have a column of their name with the appropriate values for the athlete of \code{NA} if it does not apply \cr
 }
 }

--- a/man/get_tests.Rd
+++ b/man/get_tests.Rd
@@ -85,6 +85,11 @@ Response will be a data frame containing the trials within the time range
    \strong{athlete_active} \tab \emph{logi} \tab The athlete is active \cr
    \strong{athlete_teams} \tab \emph{list} \tab List containing Ids of each team the athlete is on \cr
    \strong{athlete_groups} \tab \emph{list} \tab List containing Ids of each group the athlete is in \cr
+   \strong{athlete_image} \tab \emph{chr} \tab URL to athlete's profile image \cr
+   \strong{athlete_position} \tab \emph{chr} \tab Athlete's position \cr
+   \strong{athlete_dob} \tab \emph{chr} \tab Athlete's date of birth \cr
+   \strong{athlete_sport} \tab \emph{chr} \tab Athlete's sport \cr
+   \strong{athlete_height} \tab \emph{chr} \tab Athlete's height \cr
 }
 
 


### PR DESCRIPTION
@
## Summary

Release **hawkinR v1.2.0**. CMD-checked and source package built.

### Changes
- **`get_athletes()`** — adds athlete profile fields to returns: `image`, `position`, `dob`, `sport`, `height`, `lastTestedOn`
- **`get_tests()`** — adds athlete profile fields: `athlete_image`, `athlete_position`, `athlete_dob`, `athlete_sport`, `athlete_height`
- **Bug fix** — rewrote external-property unnesting in `get_athletes()` and `AthletePrep()` to correctly expand external value pairs into separate columns, including handling keys that vary across athletes
- **Bug fix** — `get_access()` now uses the supplied `org_name` for the `Dev` region and defaults to `v1` instead of `dev`
- Version bump `1.1.5` → `1.2.0`, changelog (`NEWS.md`) updated, regenerated docs
- Ignore `hawkinRlog.log` and `.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@