### PR TITLE
ci: build and attach source package to GitHub releases

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,43 @@
+# Builds the source package (.tar.gz) on a clean runner and attaches it
+# to the GitHub Release that triggered this workflow.
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # allows manual re-runs against an existing release
+    inputs:
+      tag:
+        description: "Existing release tag to build and attach to (e.g. v1.2.1)"
+        required: true
+
+name: release-build
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to upload assets to the release
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: build
+
+      - name: Build source package
+        run: R CMD build --no-manual .
+        shell: bash
+
+      - name: Attach package to release
+        run: gh release upload "${{ github.event.release.tag_name || inputs.tag }}" hawkinR_*.tar.gz --clobber
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@
## Summary

Adds a GitHub Actions workflow (`.github/workflows/release-build.yaml`) that builds the source package on a clean runner and attaches it to the GitHub Release as a downloadable asset.

### Behavior
- **Trigger:** `release: published` (runs automatically when a release is published), plus `workflow_dispatch` with a `tag` input for manual re-runs against an existing release.
- **Build:** `R CMD build --no-manual .` on `ubuntu-latest`, using the same `r-lib/actions` setup as the existing checks.
- **Attach:** `gh release upload <tag> hawkinR_*.tar.gz --clobber` — uploads the resulting `hawkinR_<version>.tar.gz` to the triggering release.
- Uses `actions/checkout@v4` (avoids the Node 20 deprecation affecting the older workflows).

### Notes
- Must be merged to `main` **before** publishing a release for it to trigger on that release.
- The `.tar.gz` is a build artifact produced in CI — it is not committed to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@